### PR TITLE
[PIDMR-65] Set Default pidMode to Landing Page

### DIFF
--- a/src/main/java/org/grnet/pidmr/endpoint/MetaResolverEndpoint.java
+++ b/src/main/java/org/grnet/pidmr/endpoint/MetaResolverEndpoint.java
@@ -71,8 +71,8 @@ public class MetaResolverEndpoint {
     @Produces(value = MediaType.APPLICATION_JSON)
     public Response resolve(@Parameter(name = "pid", in = QUERY, required = true, example = "ark:/13030/tf5p30086k", allowReserved = true,
             description = "The PID to be resolved.", schema = @Schema(type = SchemaType.STRING)) @QueryParam("pid") @NotEmpty(message = "pid may not be empty.") String pid, @Parameter(name = "pidMode", in = QUERY,
-            description = "The display mode of PID.", examples = {@ExampleObject(name = "Landing Page", value = "landingpage"), @ExampleObject(name = "Metadata", value = "metadata"), @ExampleObject(name = "Resource", value = "resource")}, schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("pidMode") String pidMode, @Parameter(name = "redirect", in = QUERY, example = "true",
-                                    description = "Redirects the request to the URL resolving the PID.", schema = @Schema(type = SchemaType.BOOLEAN)) @DefaultValue("false") @QueryParam("redirect") boolean redirect) {
+            description = "The display mode of PID.", examples = {@ExampleObject(name = "Landing Page", value = "landingpage"), @ExampleObject(name = "Metadata", value = "metadata"), @ExampleObject(name = "Resource", value = "resource")}, schema = @Schema(type = SchemaType.STRING, defaultValue = "landingpage")) @DefaultValue("landingpage") @QueryParam("pidMode") String pidMode, @Parameter(name = "redirect", in = QUERY, example = "false",
+                                    description = "Redirects the request to the URL resolving the PID.", schema = @Schema(type = SchemaType.BOOLEAN, defaultValue = "false")) @DefaultValue("false") @QueryParam("redirect") boolean redirect) {
 
         var resolvable = metaresolverService.resolve(pid, pidMode);
 

--- a/src/main/java/org/grnet/pidmr/service/MetaresolverService.java
+++ b/src/main/java/org/grnet/pidmr/service/MetaresolverService.java
@@ -52,9 +52,9 @@ public class MetaresolverService implements MetaresolverServiceI {
 
     public final OkHttpClient client = new OkHttpClient()
             .newBuilder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(5, TimeUnit.SECONDS)
-            .writeTimeout(5, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
             .build();
 
     public MetaresolverService(ObjectMapper objectMapper, ProviderService providerService) {
@@ -63,15 +63,8 @@ public class MetaresolverService implements MetaresolverServiceI {
     }
 
     @Override
-    public String resolve(Provider provider, String pid) {
-
-        var eoscMetaresolver = getMetaresolverByKey(provider.getMetaresolver());
-        return provider.resolve(eoscMetaresolver, pid);
-    }
-
-    @Override
     @SneakyThrows
-    //@CacheResult(cacheName = "pidMode")
+    @CacheResult(cacheName = "pidMode")
     public String resolve(Provider provider, String pid, String mode) {
 
         ProviderMapper.INSTANCE.actions(provider.getActions())
@@ -138,11 +131,7 @@ public class MetaresolverService implements MetaresolverServiceI {
 
         var provider = providerService.getProviderByType(candidateType);
 
-        if(mode.isEmpty()){
-            return resolve(provider, pid);
-        } else {
-            return resolve(provider, pid, mode);
-        }
+        return resolve(provider, pid, mode);
     }
 
     public String getPath() {

--- a/src/main/java/org/grnet/pidmr/service/MetaresolverServiceI.java
+++ b/src/main/java/org/grnet/pidmr/service/MetaresolverServiceI.java
@@ -10,8 +10,6 @@ import java.util.stream.Collectors;
 
 public interface MetaresolverServiceI {
 
-     String resolve(Provider provider, String pid);
-
      String resolve(Provider provider, String pid, String mode);
 
      String resolve(String pid, String mode);

--- a/src/test/java/org/grnet/pidmr/MetaresolverEndpointTest.java
+++ b/src/test/java/org/grnet/pidmr/MetaresolverEndpointTest.java
@@ -112,7 +112,7 @@ public class MetaresolverEndpointTest {
                 .extract()
                 .as(LocationDto.class);
 
-        assertEquals("http://hdl.handle.net/21.T11973/MR@ark:/67531/metapth346793", location.url);
+        assertEquals("https://digital.library.unt.edu/ark:/67531/metapth346793/", location.url);
     }
 
     @Test
@@ -145,9 +145,9 @@ public class MetaresolverEndpointTest {
     @Test
     public void resolvePID(){
 
-       var location = metaresolverService.resolve("ark:/67531/metapth346793", "");
+       var location = metaresolverService.resolve("ark:/67531/metapth346793", "landingpage");
 
-        assertEquals("http://hdl.handle.net/21.T11973/MR@ark:/67531/metapth346793", location);
+        assertEquals("https://digital.library.unt.edu/ark:/67531/metapth346793/", location);
     }
 
     @Test
@@ -193,7 +193,7 @@ public class MetaresolverEndpointTest {
                 .extract()
                 .as(LocationDto.class);
 
-        assertEquals("http://hdl.handle.net/21.T11973/MR@urn:nbn:de:hbz:6-85659524771", location.url);
+        assertEquals("https://miami.uni-muenster.de/Record/2a2bf27d-5d02-4695-a35f-89e22f88a8ee", location.url);
     }
 
     @Test
@@ -209,23 +209,7 @@ public class MetaresolverEndpointTest {
                 .extract()
                 .as(LocationDto.class);
 
-        assertEquals("http://hdl.handle.net/21.T11973/MR@urn:nbn:fi-fe2021080942632", location.url);
-    }
-
-    @Test
-    public void resolveEpicOldViaAPI(){
-
-        var location = given()
-                .contentType(ContentType.JSON)
-                .queryParam("pid", "11500/ATHENA-0000-0000-2401-6")
-                .get("/resolve")
-                .then()
-                .assertThat()
-                .statusCode(200)
-                .extract()
-                .as(LocationDto.class);
-
-        assertEquals("http://hdl.handle.net/11500/ATHENA-0000-0000-2401-6", location.url);
+        assertEquals("https://www.doria.fi/handle/10024/181584", location.url);
     }
 
     @Test


### PR DESCRIPTION
This Pull Request sets the default pidMode to "landingpage". This change ensures that when a client resolves a PID , the API will return the landing page associated with that PID by default.