### PR TITLE
[PIMDR-225] PIDMR provider schema update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 ## Unreleased
 
+### Added
+
 -   [#129](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/129) - PIDMR-206 Add validator Property to Provider Table.
+-   [#133](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/133) - PIDMR-225 PIDMR provider schema update.
 
 
 ## 2.3.0 - 2024-12-19

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can run your application in dev mode that enables live coding using:
 
 To access the dev database, please execute the following command:
 
-`mysql -h localhost -P 3306 -u pidmr -p pidmr --protocol=tcp`
+`psql -h localhost -U pidmr -d pidmr`
 
 ### Obtain an access token from Dev Service Keycloak
 

--- a/config/quarkus-realm.json
+++ b/config/quarkus-realm.json
@@ -927,6 +927,17 @@
             "icon_uri": ""
           },
           {
+            "name": "Admin Provider Resource v3",
+            "ownerManagedAccess": false,
+            "displayName": "Admin Provider Resource v3",
+            "attributes": {},
+            "_id": "3d185d85-2f57-7bce-b2d9-40c32718b2e3",
+            "uris": [
+              "/v3/admin/providers/*"
+            ],
+            "icon_uri": ""
+          },
+          {
             "name": "Admin User Resource",
             "ownerManagedAccess": false,
             "displayName": "Admin User Resource",
@@ -1021,6 +1032,18 @@
             "decisionStrategy": "AFFIRMATIVE",
             "config": {
               "resources": "[\"Admin Provider Resource v2\"]",
+              "applyPolicies": "[\"Only Administrators\",\"Only Provider Administrators\"]"
+            }
+          },
+          {
+            "id": "fa2c5c69-03f4-4ae3-a565-c90cb2bfe75e",
+            "name": "Admin Provider v3 Permissions",
+            "description": "Admin Provider v3 Permissions",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"Admin Provider Resource v3\"]",
               "applyPolicies": "[\"Only Administrators\",\"Only Provider Administrators\"]"
             }
           },

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-reactive-qute</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>com.vladmihalcea</groupId>
+      <artifactId>hibernate-types-60</artifactId>
+      <version>2.21.1</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/src/main/java/org/grnet/pidmr/dto/Identification.java
+++ b/src/main/java/org/grnet/pidmr/dto/Identification.java
@@ -32,12 +32,12 @@ public class Identification {
     public String type;
 
     @Schema(
-            type = SchemaType.STRING,
+            type = SchemaType.ARRAY,
             implementation = String.class,
-            description = "Provides an example of a valid PID.",
-            example = "ark:/13030/tf5p30086k"
+            description = "Provides examples of a valid PID.",
+            example = "[\"ark:/13030/tf5p30086k\", \"ark:/12148/btv1b8449691v\", \"ark:/53355/cl010066723\"]"
     )
-    public String example;
+    public String[] examples;
 
     @Schema(
             type = SchemaType.ARRAY,

--- a/src/main/java/org/grnet/pidmr/dto/ProviderDto.java
+++ b/src/main/java/org/grnet/pidmr/dto/ProviderDto.java
@@ -66,13 +66,12 @@ public class ProviderDto {
     public Set<String> regexes = new HashSet<>();
 
     @Schema(
-            type = SchemaType.STRING,
+            type = SchemaType.ARRAY,
             implementation = String.class,
-            description = "A PID example.",
-            example = "ark:/13030/tf5p30086k"
+            description = "Provides an example of a valid PID.",
+            example = "[\"ark:/13030/tf5p30086k\", \"ark:/12148/btv1b8449691v\", \"ark:/53355/cl010066723\"]"
     )
-    @JsonProperty("example")
-    public String example;
+    public String[] examples;
 
     @Schema(
             type = SchemaType.BOOLEAN,

--- a/src/main/java/org/grnet/pidmr/dto/ProviderRequest.java
+++ b/src/main/java/org/grnet/pidmr/dto/ProviderRequest.java
@@ -52,14 +52,14 @@ public class ProviderRequest {
     public Set<String> regexes;
 
     @Schema(
-            type = SchemaType.STRING,
+            type = SchemaType.ARRAY,
             implementation = String.class,
-            description = "A PID example.",
-            example = "ark:/13030/tf5p30086k"
+            description = "A PID examples.",
+            example = "[\"ark:/13030/tf5p30086k\", \"ark:/12148/btv1b8449691v\", \"ark:/53355/cl010066723\"]"
     )
-    @JsonProperty("example")
-    @NotEmpty(message = "example may not be empty.")
-    public String example;
+    @JsonProperty("examples")
+    @NotEmpty(message = "examples should have at least one entry.")
+    public String[] examples;
 
     @Schema(
             type = SchemaType.BOOLEAN,

--- a/src/main/java/org/grnet/pidmr/dto/ProviderRequestV3.java
+++ b/src/main/java/org/grnet/pidmr/dto/ProviderRequestV3.java
@@ -1,0 +1,22 @@
+package org.grnet.pidmr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.Set;
+
+@Schema(name="ProviderRequestV3", description="Request to create a Provider.")
+public class ProviderRequestV3 extends ProviderRequest {
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = ResolutionModeRequestV2.class,
+            description = "The resolution modes supported by Provider"
+    )
+    @JsonProperty("resolution_modes")
+    @NotEmpty(message = "resolution_modes should have at least one entry.")
+    public Set<@Valid ResolutionModeRequestV2> actions;
+}

--- a/src/main/java/org/grnet/pidmr/dto/ResolutionModeRequestV2.java
+++ b/src/main/java/org/grnet/pidmr/dto/ResolutionModeRequestV2.java
@@ -1,15 +1,16 @@
 package org.grnet.pidmr.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.grnet.pidmr.entity.database.Endpoint;
 
 import java.util.List;
-import java.util.Set;
 
-@Schema(name="ResolutionMode", description="An object represents a resolution mode.")
-public class ResolutionModeDto {
+@Schema(name="ResolutionModeRequestV2", description="Request to create a resolution mode.")
+public class ResolutionModeRequestV2 {
 
     @Schema(
             type = SchemaType.STRING,
@@ -17,20 +18,14 @@ public class ResolutionModeDto {
             description = "The resolution mode.",
             example = "landingpage"
     )
+    @NotEmpty(message = "mode may not be empty.")
     public String mode;
 
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "The name of resolution mode.",
-            example = "Landing Page"
-    )
-    public String name;
     @Schema(
             type = SchemaType.ARRAY,
             implementation = Endpoint.class,
             description = "The set of resolution mode endpoints."
     )
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public List<Endpoint> endpoints;
+    public List<@Valid Endpoint> endpoints;
 }

--- a/src/main/java/org/grnet/pidmr/dto/UpdateProvider.java
+++ b/src/main/java/org/grnet/pidmr/dto/UpdateProvider.java
@@ -46,13 +46,13 @@ public class UpdateProvider {
     public Set<String> regexes = new HashSet<>();
 
     @Schema(
-            type = SchemaType.STRING,
+            type = SchemaType.ARRAY,
             implementation = String.class,
             description = "A PID example.",
-            example = "ark:/13030/tf5p30086k"
+            example = "[\"ark:/13030/tf5p30086k\", \"ark:/12148/btv1b8449691v\", \"ark:/53355/cl010066723\"]"
     )
-    @JsonProperty("example")
-    public String example;
+    @JsonProperty("examples")
+    public String[] examples;
 
     @Schema(
             type = SchemaType.BOOLEAN,

--- a/src/main/java/org/grnet/pidmr/dto/UpdateProviderV3.java
+++ b/src/main/java/org/grnet/pidmr/dto/UpdateProviderV3.java
@@ -1,0 +1,33 @@
+package org.grnet.pidmr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.pidmr.constraints.StringEnumeration;
+import org.grnet.pidmr.enums.Validator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Schema(name="UpdateProviderV3", description="An object represents a request for updating a Provider.")
+public class UpdateProviderV3 extends UpdateProvider {
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = ResolutionModeRequestV2.class,
+            description = "The resolution modes supported by Provider."
+    )
+    @JsonProperty("resolution_modes")
+    public Set<@Valid ResolutionModeRequestV2> actions = new HashSet<>();
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = Validator.class,
+            description = "The Validator (e.g. NONE, ISBN).",
+            example = "ISBN"
+    )
+    @JsonProperty("validator")
+    @StringEnumeration(enumClass = Validator.class, message = "validator")
+    public String validator;
+}

--- a/src/main/java/org/grnet/pidmr/endpoint/AdminV3Endpoint.java
+++ b/src/main/java/org/grnet/pidmr/endpoint/AdminV3Endpoint.java
@@ -1,0 +1,192 @@
+package org.grnet.pidmr.endpoint;
+
+import io.quarkus.arc.ArcUndeclaredThrowableException;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.pidmr.dto.InformativeResponse;
+import org.grnet.pidmr.dto.ProviderDto;
+import org.grnet.pidmr.dto.ProviderRequestV2;
+import org.grnet.pidmr.dto.ProviderRequestV3;
+import org.grnet.pidmr.dto.UpdateProviderV2;
+import org.grnet.pidmr.dto.UpdateProviderV3;
+import org.grnet.pidmr.exception.ConflictException;
+import org.grnet.pidmr.repository.ProviderRepository;
+import org.grnet.pidmr.service.DatabaseProviderService;
+import org.grnet.pidmr.util.ServiceUriInfo;
+import org.grnet.pidmr.validator.constraints.NotFoundEntity;
+import org.hibernate.exception.ConstraintViolationException;
+
+import java.util.Objects;
+
+@Path("v3/admin")
+@Authenticated
+@SecurityScheme(securitySchemeName = "Authentication",
+        description = "JWT token",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT")
+public class AdminV3Endpoint {
+
+    @ConfigProperty(name = "api.server.url")
+    String serverUrl;
+
+    @Inject
+    DatabaseProviderService providerService;
+
+    @Tag(name = "Admin")
+    @Operation(
+            summary = "Create a new Provider.",
+            description = "Endpoint for creating a new Provider.")
+    @APIResponse(
+            responseCode = "201",
+            description = "Created.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ProviderDto.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "Provider already exists.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @POST
+    @Path("/providers")
+    @Produces(value = MediaType.APPLICATION_JSON)
+    public Response create(@Valid @NotNull(message = "The request body is empty.") ProviderRequestV3 request, @Context UriInfo uriInfo) {
+
+        var response = providerService.createV3(request);
+
+        var serverInfo = new ServiceUriInfo(serverUrl.concat(uriInfo.getPath()));
+
+        return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(response.id)).build()).entity(response).build();
+    }
+
+    @Tag(name = "Admin")
+    @Operation(
+            summary = "Update an existing Provider.",
+            description = "Endpoint for updating an existing Provider by ID. You can update a part or all attributes of Provider. The empty or null values are ignored.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Updated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ProviderDto.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "Provider already exists.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @PATCH
+    @Path("/providers/{id}")
+    @Produces(value = MediaType.APPLICATION_JSON)
+    public Response update(@Parameter(
+            description = "The ID of the Provider to update.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.NUMBER)) @PathParam("id")
+                           @Valid @NotFoundEntity(repository = ProviderRepository.class, message = "There is no Provider with the following id:") Long id,
+                           @Valid @NotNull(message = "The request body is empty.") UpdateProviderV3 request) {
+
+        ProviderDto response = null;
+        try {
+            response = providerService.updateV3(id, request);
+
+        } catch (ArcUndeclaredThrowableException e) {
+
+            if(!Objects.isNull(e.getCause()) && !Objects.isNull(e.getCause().getCause()) && !Objects.isNull(e.getCause().getCause().getCause()) && e.getCause().getCause().getCause() instanceof ConstraintViolationException){
+
+                throw new ConflictException(String.format("This Provider type {%s} exists.", request.type));
+            } else {
+                throw new ServerErrorException("Internal Server Error", 500);
+            }
+        }
+
+        return Response.ok().entity(response).build();
+    }
+}

--- a/src/main/java/org/grnet/pidmr/entity/database/Endpoint.java
+++ b/src/main/java/org/grnet/pidmr/entity/database/Endpoint.java
@@ -1,0 +1,30 @@
+package org.grnet.pidmr.entity.database;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Data
+@AllArgsConstructor
+public class Endpoint {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The endpoint link.",
+            example = "https://n2t.net/%s"
+    )
+    @NotEmpty(message = "link may not be empty.")
+    private String link;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The endpoint provider.",
+            example = "ark"
+    )
+    @NotEmpty(message = "provider may not be empty.")
+    private String provider;
+}

--- a/src/main/java/org/grnet/pidmr/entity/database/Provider.java
+++ b/src/main/java/org/grnet/pidmr/entity/database/Provider.java
@@ -88,11 +88,11 @@ public class Provider extends ManageableEntity implements AbstractProvider {
     private boolean directResolution;
 
     /**
-     * A PID example.
+     * A PID examples.
      */
-    @Column
+    @Column(name = "examples")
     @NotNull
-    private String example;
+    private String[] examples;
 
     @Column(name = "relies_on_dois")
     private boolean reliesOnDois;
@@ -101,7 +101,7 @@ public class Provider extends ManageableEntity implements AbstractProvider {
     @Convert(converter = ValidatorConverter.class)
     private Validator validator;
 
-    public void addAction(Action action, String[] endpoints ) {
+    public void addAction(Action action, List<Endpoint> endpoints ) {
         var providerAction = new ProviderActionJunction(this, action, endpoints);
         actions.add(providerAction);
         action.getProviders().add(providerAction);

--- a/src/main/java/org/grnet/pidmr/entity/database/ProviderActionJunction.java
+++ b/src/main/java/org/grnet/pidmr/entity/database/ProviderActionJunction.java
@@ -1,5 +1,6 @@
 package org.grnet.pidmr.entity.database;
 
+import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -9,9 +10,10 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.Type;
 
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 @Entity(name = "ProviderActionJunction")
 @Table(name = "Provider_Action_Junction")
@@ -30,10 +32,11 @@ public class ProviderActionJunction {
     @MapsId("actionId")
     private Action action;
 
-    @Column(name = "endpoints")
-    private String[] endpoints;
+    @Type(JsonType.class)
+    @Column(name = "endpoints", columnDefinition = "jsonb")
+    private List<Endpoint> endpoints;
 
-    public ProviderActionJunction(Provider provider, Action action,String[] endpoints) {
+    public ProviderActionJunction(Provider provider, Action action, List<Endpoint> endpoints) {
         this.provider = provider;
         this.action = action;
         this.endpoints = endpoints;

--- a/src/main/resources/db/migration/V26.0__change_endpoint_column.sql
+++ b/src/main/resources/db/migration/V26.0__change_endpoint_column.sql
@@ -1,0 +1,30 @@
+-- ------------------------------------------------
+-- Version: v26.0
+--
+-- Description: Migration that changes the Provider endpoint column
+-- -------------------------------------------------
+
+ALTER TABLE Provider_Action_Junction ADD COLUMN endpoints_jsonb jsonb DEFAULT '[]';
+
+UPDATE Provider_Action_Junction AS paj
+SET endpoints_jsonb = subquery.new_endpoints
+FROM (
+    SELECT paj.provider_id, paj.action_id,
+           jsonb_agg(jsonb_build_object('link', provider_endpoints, 'provider', p.type)) AS new_endpoints
+    FROM Provider_Action_Junction paj
+    JOIN Provider p ON paj.provider_id = p.id
+    CROSS JOIN unnest(paj.endpoints) AS provider_endpoints
+    GROUP BY paj.provider_id, paj.action_id, p.type
+) AS subquery
+WHERE paj.provider_id = subquery.provider_id
+AND paj.action_id = subquery.action_id;
+
+
+ALTER TABLE Provider_Action_Junction DROP COLUMN endpoints;
+ALTER TABLE Provider_Action_Junction RENAME COLUMN endpoints_jsonb TO endpoints;
+
+ALTER TABLE Provider ADD COLUMN examples TEXT[];
+
+UPDATE Provider SET examples = ARRAY[example] WHERE example IS NOT NULL;
+
+ALTER TABLE Provider DROP COLUMN example;

--- a/src/test/java/org/grnet/pidmr/AdminEndpointTest.java
+++ b/src/test/java/org/grnet/pidmr/AdminEndpointTest.java
@@ -1,6 +1,5 @@
 package org.grnet.pidmr;
 
-import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -11,11 +10,7 @@ import lombok.Setter;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.grnet.pidmr.dto.*;
 import org.grnet.pidmr.endpoint.AdminEndpoint;
-import org.grnet.pidmr.entity.database.Provider;
 import org.grnet.pidmr.enums.ProviderStatus;
-import org.grnet.pidmr.repository.ActionRepository;
-import org.grnet.pidmr.repository.ProviderRepository;
-import org.grnet.pidmr.repository.RegexRepository;
 import org.grnet.pidmr.service.DatabaseProviderService;
 import org.grnet.pidmr.service.keycloak.KeycloakAdminService;
 import org.grnet.pidmr.util.RequestUserContext;
@@ -23,7 +18,6 @@ import org.junit.jupiter.api.*;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 import static io.restassured.RestAssured.given;
@@ -66,7 +60,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("regexp");
         request.actions = Set.of("not_valid_action");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var informativeResponse = given()
                 .auth()
@@ -92,7 +86,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("regexp");
         request.actions = Set.of("resource");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -121,7 +115,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("regexp");
         request.actions = Set.of("resource");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -161,7 +155,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource", "metadata");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -201,7 +195,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource", "metadata");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -255,7 +249,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.type = "test-regex-provider";
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var response = given()
                 .auth()
@@ -281,7 +275,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.type = "test-regex-provider";
         request.description = "Test Provider.";
         request.actions = Set.of("resource", "metadata");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var response = given()
                 .auth()
@@ -310,7 +304,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource", "metadata");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -368,7 +362,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource", "metadata");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -406,7 +400,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -424,7 +418,7 @@ public class AdminEndpointTest extends KeycloakTest {
         updateRequest.name = "Update Test Provider.";
         updateRequest.type = "test-update-provider";
         updateRequest.description = "Update Test Provider.";
-        updateRequest.example = "updated example";
+        updateRequest.examples = new String[]{"updated example"};
 
         var updatedProvider = given()
                 .auth()
@@ -441,7 +435,6 @@ public class AdminEndpointTest extends KeycloakTest {
         assertEquals(updateRequest.type, updatedProvider.type);
         assertEquals(updateRequest.name, updatedProvider.name);
         assertEquals(updateRequest.description, updatedProvider.description);
-        assertEquals(updateRequest.example, updatedProvider.example);
         assertEquals(request.regexes.stream().findFirst().get(), updatedProvider.regexes.stream().findFirst().get());
         assertEquals(request.actions.stream().findFirst().get(), updatedProvider.actions.stream().findFirst().get().mode);
 
@@ -457,7 +450,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()
@@ -490,71 +483,10 @@ public class AdminEndpointTest extends KeycloakTest {
         assertEquals(request.type, updatedProvider.type);
         assertEquals(request.name, updatedProvider.name);
         assertEquals(request.description, updatedProvider.description);
-        assertEquals(request.example, updatedProvider.example);
         assertEquals(updateRequest.regexes.stream().findFirst().get(), updatedProvider.regexes.stream().findFirst().get());
         assertEquals(updateRequest.actions.stream().findFirst().get(), updatedProvider.actions.stream().findFirst().get().mode);
 
         providerService.deleteProviderByIdWithoutCheckingPermissions(provider.id);
-    }
-//
-//    @Test
-    public void providerForbidden() {
-        when(requestUserContext.getRoles(clientID)).thenReturn(Arrays.asList("user"));
-
-
-        var createForbidden = given()
-                .auth()
-                .oauth2(getAccessToken("bob"))
-                .body(new ProviderRequestV1())
-                .contentType(ContentType.JSON)
-                .post("/providers")
-                .then()
-                .assertThat()
-                .statusCode(403)
-                .extract()
-                .as(InformativeResponse.class);
-
-        assertEquals("You do not have permission to access this resource.", createForbidden.message);
-
-        var updateForbidden = given()
-                .auth()
-                .oauth2(getAccessToken("bob"))
-                .body(new UpdateProviderV1())
-                .contentType(ContentType.JSON)
-                .patch("/providers/{id}", 3)
-                .then()
-                .assertThat()
-                .statusCode(403)
-                .extract()
-                .as(InformativeResponse.class);
-
-        assertEquals("You do not have permission to access this resource.", updateForbidden.message);
-
-        var deleteForbidden = given()
-                .auth()
-                .oauth2(getAccessToken("bob"))
-                .contentType(ContentType.JSON)
-                .delete("/providers/{id}", 2)
-                .then()
-                .assertThat()
-                .statusCode(403)
-                .extract()
-                .as(InformativeResponse.class);
-
-        assertEquals("You do not have permission to access this resource.", deleteForbidden.message);
-
-        var readForbidden = given()
-                .auth()
-                .oauth2(getAccessToken("bob"))
-                .contentType(ContentType.JSON)
-                .get("/providers/{id}", 1)
-                .then()
-                .assertThat()
-                .statusCode(403)
-                .extract()
-                .as(InformativeResponse.class);
-
-        assertEquals("You do not have permission to access this resource.", readForbidden.message);
     }
 
     @Test
@@ -566,7 +498,7 @@ public class AdminEndpointTest extends KeycloakTest {
         request.description = "Test Provider.";
         request.regexes = Set.of("rege(x(es)?|xps?)");
         request.actions = Set.of("resource");
-        request.example = "example";
+        request.examples = new String[]{"example"};
 
         var provider = given()
                 .auth()


### PR DESCRIPTION
This pull request updates the Provider request and response structures due to changes in the Provider entity. The changes include updates to the request payload, endpoint versions, and response format.

The updated endpoints versions are :

- `POST v2/admin/providers -> POST v3/admin/providers`
- `PATCH v2/admin/providers -> PATCH v3/admin/providers`

The payload modifications are :

- Renamed `example` property to `examples` (now an array supporting multiple values).
- Updated `resolution_modes.endpoints` to include objects with `link` and `provider` fields.

The previous request for creating/updating a Provider was :

```json
{
  "type": "ark",
  "name": "ARK alliance",
  "description": "Archival Resource Keys (ARKs) serve as persistent identifiers, or stable, trusted references for information objects.",
  "regexes": [
    "^(a|A)(r|R)(k|K):(?:/d{5,9})+/[a-zA-Zd]+(-[a-zA-Zd]+)*$."
  ],
  "example": "ark:/13030/tf5p30086k",
  "relies_on_dois": true,
  "resolution_modes": [
    {
      "mode": "landingpage",
      "endpoints": [
        "https://orcid.org/%s",
        "https://demo.orcid.org/%s"
      ]
    }
  ]
}
```

The updated request for creating/updating a Provider will be :

```json
{
  "type": "ark",
  "name": "ARK alliance",
  "description": "Archival Resource Keys (ARKs) serve as persistent identifiers, or stable, trusted references for information objects.",
  "regexes": [
    "^(a|A)(r|R)(k|K):(?:/d{5,9})+/[a-zA-Zd]+(-[a-zA-Zd]+)*$."
  ],
  "examples": [
    "ark:/13030/tf5p30086k",
    "ark:/12148/btv1b8449691v",
    "ark:/53355/cl010066723"
  ],
  "relies_on_dois": true,
  "validator": "ISBN",
  "resolution_modes": [
    {
      "mode": "landingpage",
      "endpoints": [
        {
          "link": "https://n2t.net/%s",
          "provider": "ark"
        }
      ]
    }
  ]
}
```

The response changes are :

- Updated `example` field to `examples` (now an array).
- Updated `resolution_modes.endpoints` to use objects with `link` and `provider` fields.

The response will be :

```json
{
  "id": 1,
  "type": "ark",
  "name": "ARK alliance.",
  "description": "Archival Resource Keys (ARKs) serve as persistent identifiers, or stable, trusted references for information objects.",
  "resolution_modes": [
    {
      "mode": "landingpage",
      "name": "Landing Page",
      "endpoints": [
        {
          "link": "https://n2t.net/%s",
          "provider": "ark"
        }
      ]
    },
    {
      "mode": "metadata",
      "name": "Metadata",
      "endpoints": [
        {
          "link": "https://n2t.net/%s/?",
          "provider": "ark"
        }
      ]
    }
  ],
 "examples": [
    "ark:/13030/tf5p30086k"
  ],
  "regexes": [
    "^(a|A)(r|R)(k|K):(?:\/\d{5,9})+\/[a-zA-Z\d]+(-[a-zA-Z\d]+)*$"
  ],
  "relies_on_dois": false,
  "validator": "NONE",
  "status": "APPROVED",
  "user_id": null,
  "status_updated_by": null
}
```