### PR TITLE
PIDMR-238: Create Endpoint for Getting a Provider by ID for Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 -   [#129](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/129) - PIDMR-206 Add validator Property to Provider Table.
 -   [#133](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/133) - PIDMR-225 PIDMR provider schema update.
+  - [#138](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/138) PIDMR-238 Create Endpoint for Getting a Provider by ID for Users
 
 
 ## 2.3.0 - 2024-12-19

--- a/src/main/java/org/grnet/pidmr/endpoint/ProviderEndpoint.java
+++ b/src/main/java/org/grnet/pidmr/endpoint/ProviderEndpoint.java
@@ -6,25 +6,14 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotAcceptableException;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.grnet.pidmr.dto.Identification;
-import org.grnet.pidmr.dto.InformativeResponse;
-import org.grnet.pidmr.dto.PidIdentificationBatchRequest;
-import org.grnet.pidmr.dto.PidIdentificationBatchResponse;
-import org.grnet.pidmr.dto.PidMultipleIdentificationBatchResponse;
-import org.grnet.pidmr.dto.ProviderDto;
-import org.grnet.pidmr.dto.Validity;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.grnet.pidmr.dto.*;
 import org.grnet.pidmr.pagination.PageResource;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -33,7 +22,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.pidmr.repository.ProviderRepository;
 import org.grnet.pidmr.service.DatabaseProviderService;
+import org.grnet.pidmr.validator.constraints.NotFoundEntity;
 
 
 import java.io.UnsupportedEncodingException;
@@ -78,6 +69,40 @@ public class ProviderEndpoint {
 
         return Response.ok().entity(providerService.pagination(page - 1, size, uriInfo)).build();
     }
+
+    @Tag(name = "Provider")
+    @Operation(
+            summary = "Get Provider by ID.",
+            description = "Endpoint for retrieving a Provider by its ID.")
+    @APIResponse(
+            responseCode = "200",
+            description = "The requested Provider.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ProviderDto.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @GET
+    @Path("/{id}")
+    @Produces(value = MediaType.APPLICATION_JSON)
+    public Response getProviderById(
+            @Parameter(
+                    description = "The ID of the Provider to retrieve.",
+                    required = true,
+                    example = "1",
+                    schema = @Schema(type = SchemaType.NUMBER))
+            @PathParam("id")
+            @Valid @NotFoundEntity(repository = ProviderRepository.class, message = "There is no Provider with the following id:") Long id) {
+
+        var response = providerService.getById(id);
+
+        return Response.ok().entity(response).build();
+    }
+
 
     @Tag(name = "Provider")
     @Operation(

--- a/src/main/java/org/grnet/pidmr/service/DatabaseProviderService.java
+++ b/src/main/java/org/grnet/pidmr/service/DatabaseProviderService.java
@@ -606,4 +606,11 @@ public class DatabaseProviderService implements ProviderServiceI {
 
         return identification;
     }
+    @Transactional
+    public ProviderDto getById(Long providerId) {
+
+        var provider = providerRepository.findById(providerId);
+
+        return ProviderMapper.INSTANCE.databaseProviderToDto(provider);
+    }
 }

--- a/src/main/java/org/grnet/pidmr/service/ProviderService.java
+++ b/src/main/java/org/grnet/pidmr/service/ProviderService.java
@@ -12,6 +12,7 @@ import org.grnet.pidmr.dto.Identification;
 import org.grnet.pidmr.dto.Validity;
 import org.grnet.pidmr.entity.Action;
 import org.grnet.pidmr.entity.Provider;
+import org.grnet.pidmr.interceptors.ManageEntity;
 import org.grnet.pidmr.mapper.ProviderMapper;
 import org.grnet.pidmr.pagination.Page;
 import org.grnet.pidmr.pagination.PageResource;

--- a/src/test/java/org/grnet/pidmr/ProviderEndpointTest.java
+++ b/src/test/java/org/grnet/pidmr/ProviderEndpointTest.java
@@ -8,11 +8,13 @@ import lombok.Setter;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.grnet.pidmr.dto.Identification;
 import org.grnet.pidmr.dto.InformativeResponse;
+import org.grnet.pidmr.dto.ProviderDto;
 import org.grnet.pidmr.dto.Validity;
 import org.grnet.pidmr.endpoint.ProviderEndpoint;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
+import org.grnet.pidmr.entity.database.Provider;
 import org.grnet.pidmr.repository.ProviderRepository;
 import org.grnet.pidmr.service.keycloak.KeycloakAdminService;
 import org.grnet.pidmr.util.RequestUserContext;
@@ -577,5 +579,39 @@ public class ProviderEndpointTest {
                 .as(Identification.class);
 
         assertEquals("10.5281/zenodo", identification1.type);
+    }
+
+
+    @Test
+    public void getProviderNotFound() {
+
+        var response = given()
+                .basePath("v1/providers")
+                .contentType(ContentType.JSON)
+                .get("/{id}", 1000L)
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("There is no Provider with the following id: " + 1000L, response.message);
+    }
+
+
+    @Test
+    public void getProvider() {
+
+        var response = given()
+                .basePath("v1/providers")
+                .contentType(ContentType.JSON)
+                .get("/{id}", 3)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(ProviderDto.class);
+
+        assertEquals("swh", response.type);
     }
 }


### PR DESCRIPTION
### Actions:
We created a new endpoint that allows users to retrieve a provider by its unique ID. The new endpoint (GET /v1/providers/{id}) will return detailed information about the provider.

### Endpoint:
Method: GET
* Path: /v1/providers/{id}
* Parameters:
  * id: The ID of the provider.

### Example Response:
```
{
  "examples": [
    "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
  ],
  "id": 3,
  "type": "swh",
  "name": "Software heritage persistent identifiers.",
  "description": "You can point to objects present in the Software Heritage archive by the means of SoftWare Heritage persistent IDentifiers, or SWHIDs for short, that are guaranteed to remain stable (persistent) over time.",
  "resolution_modes": [
    {
      "mode": "metadata",
      "name": "Metadata",
      "endpoints": []
    },
    {
      "mode": "landingpage",
      "name": "Landing Page",
      "endpoints": []
    },
    {
      "mode": "resource",
      "name": "Resource",
      "endpoints": []
    }
  ],
  "regexes": [
    "^(s|S)(w|W)(h|H):[1-9]:(cnt|dir|rel|rev|snp):[0-9a-f]+(;(origin|visit|anchor|path|lines)=\\S+)*$"
  ],
  "relies_on_dois": false,
  "validator": "NONE"
}
```