### PR TITLE
PIDMR-240: The supported modes in API are not returned in an order

### DIFF
--- a/src/main/java/org/grnet/pidmr/repository/ProviderRepository.java
+++ b/src/main/java/org/grnet/pidmr/repository/ProviderRepository.java
@@ -41,7 +41,7 @@ public class ProviderRepository implements Repository<Provider, Long> {
      */
     public Pageable<Provider> fetchProvidersByPage(int page, int size){
 
-        var panache = find("status = : status", Parameters.with("status", ProviderStatus.APPROVED)).page(page, size);
+        var panache = find("status = :status ORDER BY name ASC", Parameters.with("status", ProviderStatus.APPROVED)).page(page, size);
 
         var pageable = new PageableImpl<Provider>();
         pageable.list = panache.list();


### PR DESCRIPTION
## Add Sorting by Name in fetchProvidersByPage Method

We updated the fetchProvidersByPage method to include sorting by the name field in ascending order. This change ensures that the returned list of providers is ordered alphabetically by their name.
### Changes Made:
- Added ORDER BY name ASC to the find() query in the fetchProvidersByPage method.