### PR TITLE
[PIDMR-254] Add Image Upload Endpoint with Provider-Based Folder Structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 -   [#142](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/142) - PIDMR-188 API update status.
 -   [#143](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/143) - PIDMR-251 Add metadata_path property to Provider entity and update related endpoints.
+-   [#149](https://github.com/FC4E-WP5/fc4eosc-PIDMR-api/pull/149) - PIDMR-254 Add Image Upload Endpoint with Provider-Based Folder Structure.
 
 
 ## 2.4.0 - 2025-03-27

--- a/src/main/java/org/grnet/pidmr/dto/ProviderDto.java
+++ b/src/main/java/org/grnet/pidmr/dto/ProviderDto.java
@@ -99,4 +99,13 @@ public class ProviderDto {
     )
     @JsonProperty("resource_path_in_metadata")
     public Set<MetadataPathEntry> metadataPathEntries = new HashSet<>();
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The image url path.",
+            example = "/v1/providers/1/upload/images"
+    )
+    @JsonProperty("image_url_path")
+    public String imageUrlPath;
 }

--- a/src/main/java/org/grnet/pidmr/dto/ProviderRequestV3.java
+++ b/src/main/java/org/grnet/pidmr/dto/ProviderRequestV3.java
@@ -28,4 +28,15 @@ public class ProviderRequestV3 extends ProviderRequest {
     )
     @JsonProperty("resource_path_in_metadata")
     public Set<MetadataPathEntry> metadataPathEntries;
+
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Base64-encoded image (with or without data URI prefix)",
+            example = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+            format = "byte"
+    )
+    @JsonProperty("image_base_64")
+    public String imageBase64;
 }

--- a/src/main/java/org/grnet/pidmr/dto/UpdateProviderV3.java
+++ b/src/main/java/org/grnet/pidmr/dto/UpdateProviderV3.java
@@ -39,4 +39,14 @@ public class UpdateProviderV3 extends UpdateProvider {
     )
     @JsonProperty("resource_path_in_metadata")
     public Set<MetadataPathEntry> metadataPathEntries = new HashSet<>();
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Base64-encoded image (with or without data URI prefix)",
+            example = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+            format = "byte"
+    )
+    @JsonProperty("image_base_64")
+    public String imageBase64;
 }

--- a/src/main/java/org/grnet/pidmr/endpoint/AdminEndpoint.java
+++ b/src/main/java/org/grnet/pidmr/endpoint/AdminEndpoint.java
@@ -36,7 +36,6 @@ import org.grnet.pidmr.dto.UpdateProviderStatus;
 import org.grnet.pidmr.dto.UpdateRoleChangeRequestStatus;
 import org.grnet.pidmr.dto.UserProfileDto;
 import org.grnet.pidmr.dto.ValidatorResponse;
-import org.grnet.pidmr.enums.ProviderStatus;
 import org.grnet.pidmr.exception.ConflictException;
 import org.grnet.pidmr.pagination.PageResource;
 import org.grnet.pidmr.repository.ProviderRepository;
@@ -48,6 +47,7 @@ import org.grnet.pidmr.util.ServiceUriInfo;
 import org.grnet.pidmr.validator.constraints.NotFoundEntity;
 import org.hibernate.exception.ConstraintViolationException;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 

--- a/src/main/java/org/grnet/pidmr/endpoint/AdminV3Endpoint.java
+++ b/src/main/java/org/grnet/pidmr/endpoint/AdminV3Endpoint.java
@@ -5,6 +5,7 @@ import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;

--- a/src/main/java/org/grnet/pidmr/endpoint/ProviderEndpoint.java
+++ b/src/main/java/org/grnet/pidmr/endpoint/ProviderEndpoint.java
@@ -26,7 +26,6 @@ import org.grnet.pidmr.repository.ProviderRepository;
 import org.grnet.pidmr.service.DatabaseProviderService;
 import org.grnet.pidmr.validator.constraints.NotFoundEntity;
 
-
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -247,6 +246,45 @@ public class ProviderEndpoint {
         var response = providerService.getResolutionModes();
 
         return Response.ok().entity(response).build();
+    }
+
+    @Tag(name = "Provider")
+    @Operation(
+            summary = "Retrieves an image under a provider-based folder.",
+            description = "Retrieves an image under a provider-based folder."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "Image retrieved successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @GET
+    @Path("/{id}/upload/images")
+    @Produces({"image/jpeg", "image/png"})
+    public Response getImage(@Parameter(
+            description = "The ID of the Provider.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.NUMBER))
+                             @PathParam("id")
+                             @Valid @NotFoundEntity(repository = ProviderRepository.class, message = "There is no Provider with the following id:") Long id) {
+
+        var image = providerService.getUploadedImage(id);
+
+        return Response.ok(image).build();
     }
 
     public static class PageableProvider extends PageResource<ProviderDto> {

--- a/src/main/java/org/grnet/pidmr/service/AdminService.java
+++ b/src/main/java/org/grnet/pidmr/service/AdminService.java
@@ -24,6 +24,8 @@ public class AdminService {
     @Inject
     RoleChangeRequestsRepository roleChangeRequestsRepository;
 
+    @Inject Utility utility;
+
     /**
      * Retrieves a page of RoleChangeRequestDto objects.
      *
@@ -44,7 +46,7 @@ public class AdminService {
                 .map(validator -> new ValidatorResponse(validator.name(), validator.getDescription()))
                 .collect(Collectors.toList());
 
-        var partition = Utility.partition(new ArrayList<>(allValidators), size);
+        var partition = utility.partition(new ArrayList<>(allValidators), size);
 
         var validators = partition.get(page) == null ? Collections.EMPTY_LIST : partition.get(page);
 

--- a/src/main/java/org/grnet/pidmr/service/ProviderService.java
+++ b/src/main/java/org/grnet/pidmr/service/ProviderService.java
@@ -3,8 +3,8 @@ package org.grnet.pidmr.service;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.UriInfo;
@@ -12,7 +12,6 @@ import org.grnet.pidmr.dto.Identification;
 import org.grnet.pidmr.dto.Validity;
 import org.grnet.pidmr.entity.Action;
 import org.grnet.pidmr.entity.Provider;
-import org.grnet.pidmr.interceptors.ManageEntity;
 import org.grnet.pidmr.mapper.ProviderMapper;
 import org.grnet.pidmr.pagination.Page;
 import org.grnet.pidmr.pagination.PageResource;
@@ -44,6 +43,8 @@ public class ProviderService implements ProviderServiceI {
     @ConfigProperty(name = "list.actions.file")
     String actionsPath;
 
+    @Inject
+    Utility utility;
 
     /**
      * This method is responsible for paginating the available Providers.
@@ -58,7 +59,7 @@ public class ProviderService implements ProviderServiceI {
 
         var allProviders = getProviders();
 
-        var partition = Utility.partition(new ArrayList<>(allProviders), size);
+        var partition = utility.partition(new ArrayList<>(allProviders), size);
 
         var providers = partition.get(page) == null ? Collections.EMPTY_LIST : partition.get(page);
 
@@ -91,7 +92,7 @@ public class ProviderService implements ProviderServiceI {
                 .enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)
                 .build();
 
-        return Utility.toSet(Provider.class, mapper, providersPath);
+        return utility.toSet(Provider.class, mapper, providersPath);
     }
 
     /**
@@ -105,7 +106,7 @@ public class ProviderService implements ProviderServiceI {
                 .builder()
                 .build();
 
-        return Utility.toSet(Action.class, mapper, actionsPath);
+        return utility.toSet(Action.class, mapper, actionsPath);
     }
 
     /**

--- a/src/main/java/org/grnet/pidmr/service/UserService.java
+++ b/src/main/java/org/grnet/pidmr/service/UserService.java
@@ -60,6 +60,8 @@ public class UserService {
     @Inject
     HistoryRepository historyRepository;
 
+    @Inject Utility utility;
+
     public UserProfileDto getUserProfile(){
 
         var dto = new UserProfileDto();
@@ -199,7 +201,7 @@ public class UserService {
 
         var users = getUsers();
 
-        var partition = Utility.partition(new ArrayList<>(users), size);
+        var partition = utility.partition(new ArrayList<>(users), size);
 
         var partitionedUsers = partition.get(page) == null ? Collections.EMPTY_LIST : partition.get(page);
 

--- a/src/main/java/org/grnet/pidmr/util/Utility.java
+++ b/src/main/java/org/grnet/pidmr/util/Utility.java
@@ -1,8 +1,9 @@
 package org.grnet.pidmr.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.cache.CacheResult;
+import jakarta.enterprise.context.ApplicationScoped;
 import lombok.SneakyThrows;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -17,7 +18,12 @@ import static java.util.stream.Collectors.toMap;
 /**
  * This class should contain general methods used by the API components.
  */
+
+@ApplicationScoped
 public class Utility {
+
+    @ConfigProperty(name = "base.upload.image.dir")
+    String baseUploadImageDir;
 
     /**
      * This method paginates a list of objects.
@@ -26,7 +32,7 @@ public class Utility {
      * @param pageSize The page size.
      * @return A map containing the pages of objects.
      */
-    public static <T> Map<Integer, List<T>> partition(List<T> list, int pageSize) {
+    public <T> Map<Integer, List<T>> partition(List<T> list, int pageSize) {
 
         return IntStream.iterate(0, i -> i + pageSize)
                 .limit((list.size() + pageSize - 1) / pageSize)
@@ -48,8 +54,12 @@ public class Utility {
      * @throws RuntimeException If the parsing is not completed successfully.
      */
     @SneakyThrows(IOException.class)
-    public static <T> Set<T> toSet(Class<T> clazz, ObjectMapper objectMapper, String pathToJson) {
+    public <T> Set<T> toSet(Class<T> clazz, ObjectMapper objectMapper, String pathToJson) {
 
        return objectMapper.readValue(Paths.get(pathToJson).toFile(), objectMapper.getTypeFactory().constructCollectionType(Set.class, clazz));
+    }
+
+    public String getBaseUploadImageDir() {
+        return baseUploadImageDir;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -149,3 +149,5 @@ quarkus.keycloak.admin-client.enabled=true
 #ui url
 api.ui.url=http://localhost:3000
 api.name=pidmr
+
+base.upload.image.dir=/opt/quarkus-api


### PR DESCRIPTION
This PR adds support for assigning a provider logo during creation or update of a Provider by using a new attribute: **image_base_64**.

A provider can now have an image (logo) assigned by including the image data as a Base64-encoded string with MIME type in the **image_base_64** attribute. The image is stored on the server and a public URL is returned in the response via the **image_url_path** attribute.

🔁 Create Provider (POST /v3/admin/providers) / Update Provider (PATCH /v3/admin/providers)

Request body:

```
{
  "type": "ark",
  "name": "ARK alliance",
  "description": "Archival Resource Keys (ARKs) serve as persistent identifiers, or stable, trusted references for information objects.",
  "regexes": [
    "^(a|A)(r|R)(k|K):(?:/d{5,9})+/[a-zA-Zd]+(-[a-zA-Zd]+)*$."
  ],
  "examples": [
    "ark:/13030/tf5p30086k"
  ],
  "relies_on_dois": true,
  "validator": "ISBN",
  "resolution_modes": [
    {
      "mode": "landingpage",
      "endpoints": [
        {
          "link": "https://n2t.net/%s",
          "provider": "ark"
        }
      ]
    }
  ],
  "resource_path_in_metadata": [
    {
      "provider": "ark",
      "path": "https://n2t.net/%s/?"
    }
  ],
  "image_base_64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
}

```

✅ Retrieve Provider (GET /v1/admin/providers/{id})

Response includes:

`"image_url_path": "/v1/providers/1/upload/images"
`

To fetch the actual image: `GET /v1/providers/{id}/upload/images`


Notes

- Only PNG and JPEG image formats are supported.
- Maximum image size: 5MB.
- The image must be sent in Base64 format with a MIME prefix, e.g.:
`data:image/png;base64,iVBORw0KGgoAAAANSUh...
`