### PR TITLE
Update jenkins file to use java17 image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('PIDMR API Packaging & Testing') {
             agent {
                 docker {
-                    image 'argo.registry:5000/epel-7-java11-mvn384'
+                    image 'argo.registry:5000/rocky9-java17-mvn3.9.9:latest'
                     args '-v $HOME/.m2:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -u root:root'
                 }
             }


### PR DESCRIPTION
_🚀  On the path to migrate to quarkus 3.27_

### Goal: Update jenkins file for quarkus 3.27 requirements:

- Java 17
- Maven 3.9.9

Docker image based on rocky 9 linux 